### PR TITLE
Feature/webops missing webpath

### DIFF
--- a/web/modules/custom/shp_backup/shp_backup.module
+++ b/web/modules/custom/shp_backup/shp_backup.module
@@ -114,6 +114,9 @@ function shp_backup_node_insert(NodeInterface $node) {
   }
 }
 
+/**
+ * Implements hook_operation_alter().
+ */
 function shp_backup_entity_operation_alter(array &$operations, EntityInterface $entity) {
   $account = \Drupal::currentUser();
   // Operations are applied to the shp_environment entity.

--- a/web/modules/custom/shp_orchestration/shp_orchestration.module
+++ b/web/modules/custom/shp_orchestration/shp_orchestration.module
@@ -92,8 +92,8 @@ function shp_orchestration_shp_distribution_form_validate(array $form, FormState
 /**
  * Implements hook_shp_env_vars().
  */
-function shp_orchestration_shp_env_vars(NodeInterface $node) {
-  $site = $node->get('field_shp_site')
+function shp_orchestration_shp_env_vars(NodeInterface $environment) {
+  $site = $environment->get('field_shp_site')
     ->first()
     ->get('entity')
     ->getTarget()
@@ -105,10 +105,11 @@ function shp_orchestration_shp_env_vars(NodeInterface $node) {
     'SHEPHERD_URL' => \Drupal::service('router.request_context')->getCompleteBaseUrl(),
     // @todo Ensure deployment secret has SHEPHERD_TOKEN set.
     'SHEPHERD_TOKEN_FILE' => '/etc/secret/SHEPHERD_TOKEN',
+    'WEB_PATH' => $environment->field_shp_path->value,
   ];
 
   // Append custom environment variables.
-  foreach ($node->get('field_shp_env_vars')->getValue() as $env_var) {
+  foreach ($environment->get('field_shp_env_vars')->getValue() as $env_var) {
     $env_vars[$env_var['key']] = $env_var['value'];
   }
   return $env_vars;


### PR DESCRIPTION
Run a new install and run the dev content generate script.
The WCMS site launched should be available immediately from the nip.io address.
Previously, you had to manually configure the WEB_PATH environment variable. Easily verifiable in jOpenShift UI.