### PR TITLE
Removed DATABASE_PASSWORD env var

### DIFF
--- a/web/modules/custom/shp_database_provisioner/shp_database_provisioner.module
+++ b/web/modules/custom/shp_database_provisioner/shp_database_provisioner.module
@@ -117,12 +117,6 @@ function shp_database_provisioner_shp_env_vars(EntityInterface $entity) {
     'DATABASE_PORT' => $config->get('port'),
     'DATABASE_NAME' => 'env_' . $entity->id(),
     'DATABASE_USER' => 'user_' . $entity->id(),
-    // @todo Remove the following once file-based password works successfully.
-    'DATABASE_PASSWORD' => [
-      // Automatically replaced with deployment config secret name.
-      'secret' => '_default',
-      'secret_key' => 'DATABASE_PASSWORD',
-    ],
     // The following path is based on convention set in:
     // OpenShiftOrchestrationProvider::setupVolumes()
     // The 'default' deployment config secret is mounted at /etc/secret.


### PR DESCRIPTION
Fixes the relevant todo. Our shepherd-drupal-scaffold supports the `DATABASE_PASSWORD_FILE` env var so this one is no longer needed.