### PR TITLE
Add tmp dir to docker-compose, fix incorrect public dir setting.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,8 @@ services:
       DATABASE_USER: user
       DATABASE_PASSWORD: password
       PRIVATE_DIR: /shared/private
-      PUBLIC_DIR: web/sites/default/files
+      TMP_DIR: /shared/tmp
+      PUBLIC_DIR: /shared/public
       HASH_SALT: random-hash
       CONFIG_SYNC_DIRECTORY: /shared/private/random-hash/sync
       SHEPHERD_INSTALL_PROFILE: shepherd


### PR DESCRIPTION
Add tmp dir support and fix public_dir support so it means what its supposed to.
Basically, its the mount point, it will always appear at /code/web/sites/default/files
Other MR's related to come.