### PR TITLE
Remove the orchestration provider from constructor

### DIFF
--- a/web/modules/custom/shepherd/shp_custom/shp_custom.module
+++ b/web/modules/custom/shepherd/shp_custom/shp_custom.module
@@ -283,7 +283,7 @@ function shp_custom_form_node_shp_environment_form_alter(&$form, FormStateInterf
  * Implements hook_form_FORM_ID_alter().
  */
 function shp_custom_form_node_shp_site_form_alter(&$form, FormStateInterface $form_state) {
-  Drupal::service('shp_custom.site')->formAlter($form, $form_state);
+  \Drupal::service('shp_custom.site')->formAlter($form, $form_state);
 }
 
 /**

--- a/web/modules/custom/shepherd/shp_custom/src/Service/Environment.php
+++ b/web/modules/custom/shepherd/shp_custom/src/Service/Environment.php
@@ -108,7 +108,7 @@ class Environment {
     $this->site = $site;
     // @todo - too many cross dependencies on this service, causing install failures. Fix.
     // Pull statically for now.
-    $this->orchestrationProvider = \Drupal::service('plugin.manager.orchestration_provider')->getProviderInstance();
+
   }
 
   /**
@@ -230,6 +230,7 @@ class Environment {
    *   Entity to apply operations to.
    */
   public function operationsLinksAlter(array &$operations, EntityInterface $entity) {
+    $orchestrationProvider = \Drupal::service('plugin.manager.orchestration_provider')->getProviderInstance();
     $site = $entity->field_shp_site->target_id;
     $environment = $entity->id();
     $environment_term = Term::load($entity->field_shp_environment_type->target_id);
@@ -256,13 +257,13 @@ class Environment {
     $site = $entity->field_shp_site->entity;
     $project = $site->field_shp_project->entity;
 
-    $terminal = $this->orchestrationProvider->getTerminalUrl(
+    $terminal = $orchestrationProvider->getTerminalUrl(
       $project->getTitle(),
       $site->field_shp_short_name->value,
       $entity->id()
     );
 
-    $logs = $this->orchestrationProvider->getLogUrl(
+    $logs = $orchestrationProvider->getLogUrl(
       $project->getTitle(),
       $site->field_shp_short_name->value,
       $entity->id()


### PR DESCRIPTION
The orchestration provider object has a closure or db connection in it that is causing the following : 

`Exception: Serialization of &amp;#039;Closure&amp;#039; is not allowed in serialize() (line 14 of /code/web/core/lib/Drupal/Component/Serialization/PhpSerialize.php)` 

This is due to the Environment service altering a form with an ajax callback that calls a method on the service itself. The formbuilder appears to storing this object ( Environment service ) in cache and serialising. Causing the above exception in the logs. 