### PR TITLE
Fix the callback to not supply an object as the callback class and av…

### DIFF
--- a/web/modules/custom/shepherd/shp_custom/shp_custom.module
+++ b/web/modules/custom/shepherd/shp_custom/shp_custom.module
@@ -299,3 +299,13 @@ function shp_custom_entity_operation_alter(array &$operations, EntityInterface $
     \Drupal::service('shp_custom.environment')->operationsLinksAlter($operations, $entity);
   }
 }
+
+/**
+ * Callback for setting the domain and path on add environment form.
+ *
+ * @param array $form
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ */
+function shp_custom_set_domain_path(array &$form, FormStateInterface $form_state, $request) {
+  return \Drupal::service('shp_custom.environment')->setDomainPath($form, $form_state, $request);
+}

--- a/web/modules/custom/shepherd/shp_custom/src/Service/Environment.php
+++ b/web/modules/custom/shepherd/shp_custom/src/Service/Environment.php
@@ -171,7 +171,7 @@ class Environment {
    */
   public function applyJavascriptEnvironmentType(array &$form) {
     $form['field_shp_environment_type']['widget']['#ajax'] = [
-      'callback' => [$this, 'setDomainPath'],
+      'callback' => 'shp_custom_set_domain_path',
       'event' => 'change',
       'progress' => [
         'type' => 'throbber',


### PR DESCRIPTION
…oid calling non-static methods from static context.

This MR should supercede https://github.com/universityofadelaide/shepherd/pull/63. It addresses the actual problem with the callback definition being supplied an object, rather than a class name... which caused more problems because of the static context in which it was called.