### PR TITLE
Provide validation on OpenShift config form.

### DIFF
--- a/web/modules/custom/shepherd/shp_orchestration/src/Form/OpenShiftConfigEntityForm.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/Form/OpenShiftConfigEntityForm.php
@@ -152,7 +152,8 @@ class OpenShiftConfigEntityForm extends EntityForm {
   protected function getErrorFieldName(array $client_response): string {
     $field_name = '';
     switch ($client_response['code']) {
-      case 0 && strpos($client_response['message'], 'SSL') >= 0:
+      // Some curl errors return a non http code - 0.
+      case FALSE:
         // SSL Certificate issue.
         $field_name = 'verify_tls';
         break;

--- a/web/modules/custom/shepherd/shp_orchestration/src/Form/OpenShiftConfigEntityForm.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/Form/OpenShiftConfigEntityForm.php
@@ -152,7 +152,7 @@ class OpenShiftConfigEntityForm extends EntityForm {
   protected function getErrorFieldName(array $client_response): string {
     $field_name = '';
     switch ($client_response['code']) {
-      case 0 && strpos($client_response['message'], 'SSL'):
+      case 0 && strpos($client_response['message'], 'SSL') >= 0:
         // SSL Certificate issue.
         $field_name = 'verify_tls';
         break;

--- a/web/modules/custom/shepherd/shp_orchestration/src/Form/OpenShiftConfigEntityForm.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/Form/OpenShiftConfigEntityForm.php
@@ -72,6 +72,8 @@ class OpenShiftConfigEntityForm extends EntityForm {
    */
   public function validateForm(array &$form, FormStateInterface $form_state) {
 
+    parent::validateForm($form, $form_state);
+
     $client_response = $this->validateClientConfiguration(
       $form['endpoint']['#value'],
       $form['token']['#value'],
@@ -83,8 +85,6 @@ class OpenShiftConfigEntityForm extends EntityForm {
       $field_name = $this->getErrorFieldName($client_response);
       $form_state->setErrorByName($field_name, $client_response['code'] . ':' . $client_response['message']);
     }
-
-    parent::validateForm($form, $form_state);
   }
 
   /**

--- a/web/modules/custom/shepherd/shp_orchestration/src/Form/OpenShiftConfigEntityForm.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/Form/OpenShiftConfigEntityForm.php
@@ -31,17 +31,17 @@ class OpenShiftConfigEntityForm extends EntityForm {
       '#default_value' => $entity->endpoint,
       '#required' => TRUE,
     ];
+    $form['verify_tls'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Verify TLS'),
+      '#default_value' => $entity->verify_tls,
+    ];
     $form['token'] = [
       '#type' => 'textarea',
       '#title' => $this->t('Token'),
       '#default_value' => $entity->token,
       '#attributes' => ['autocomplete' => 'off'],
       '#required' => TRUE,
-    ];
-    $form['verify_tls'] = [
-      '#type' => 'checkbox',
-      '#title' => $this->t('Verify TLS'),
-      '#default_value' => $entity->verify_tls,
     ];
     $form['namespace'] = [
       '#type' => 'textfield',
@@ -83,7 +83,11 @@ class OpenShiftConfigEntityForm extends EntityForm {
 
     if (isset($client_response['error']) && $client_response['error']) {
       $field_name = $this->getErrorFieldName($client_response);
-      $form_state->setErrorByName($field_name, $client_response['code'] . ':' . $client_response['message']);
+      $form_state->setErrorByName($field_name,
+        $this->t('Error: %response_code - %message', [
+          '%response_code' => $client_response['code'],
+          '%message' => !empty($client_response['message']) ? $client_response['message'] : "Can't connect, check that OpenShift is accessible.",
+        ]));
     }
   }
 
@@ -154,8 +158,8 @@ class OpenShiftConfigEntityForm extends EntityForm {
     switch ($client_response['code']) {
       // Some curl errors return a non http code - 0.
       case FALSE:
-        // SSL Certificate issue.
-        $field_name = 'verify_tls';
+        // Not available at the endpoint or SSL Certificate issue.
+        $field_name = 'endpoint';
         break;
 
       case 401:

--- a/web/modules/custom/shepherd/shp_orchestration/src/Form/OpenShiftConfigEntityForm.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/Form/OpenShiftConfigEntityForm.php
@@ -80,22 +80,7 @@ class OpenShiftConfigEntityForm extends EntityForm {
     );
 
     if (isset($client_response['error']) && $client_response['error']) {
-      switch ($client_response['code']) {
-        case 0 && strpos($client_response['message'], 'SSL'):
-          // SSL Certificate issue.
-          $field_name = 'verify_tls';
-          break;
-
-        case 401:
-          // Token is invalid.
-          $field_name = 'token';
-          break;
-
-        case 403:
-          // Cannot access namespace with token.
-          $field_name = 'namespace';
-          break;
-      }
+      $field_name = $this->getErrorFieldName($client_response);
       $form_state->setErrorByName($field_name, $client_response['code'] . ':' . $client_response['message']);
     }
 
@@ -153,6 +138,36 @@ class OpenShiftConfigEntityForm extends EntityForm {
     }
 
     return $response;
+  }
+
+  /**
+   * Determines field to display the error message on based on the response.
+   *
+   * @param array $client_response
+   *   Response from the client.
+   *
+   * @return string
+   *   Field name to attach error message to.
+   */
+  protected function getErrorFieldName(array $client_response): string {
+    $field_name = '';
+    switch ($client_response['code']) {
+      case 0 && strpos($client_response['message'], 'SSL'):
+        // SSL Certificate issue.
+        $field_name = 'verify_tls';
+        break;
+
+      case 401:
+        // Token is invalid.
+        $field_name = 'token';
+        break;
+
+      case 403:
+        // Cannot access namespace with token.
+        $field_name = 'namespace';
+        break;
+    }
+    return $field_name;
   }
 
 }


### PR DESCRIPTION
Connect to OpenShift via the client with the user provided values to verify valid configuration. Currently we assume that all config provided to this form is correct and provide no feedback. A user who enters invalid config will not know until they are creating projects or sites and often it fails silently. 