### PR TITLE
Feature/webops 278 environment build status

### DIFF
--- a/web/modules/custom/shepherd/shp_custom/config/optional/views.view.shp_site_environments.yml
+++ b/web/modules/custom/shepherd/shp_custom/config/optional/views.view.shp_site_environments.yml
@@ -30,7 +30,7 @@ display:
         options:
           perm: 'access content'
       cache:
-        type: tag
+        type: none
         options: {  }
       query:
         type: views_query

--- a/web/modules/custom/shepherd/shp_custom/config/optional/views.view.shp_site_environments.yml
+++ b/web/modules/custom/shepherd/shp_custom/config/optional/views.view.shp_site_environments.yml
@@ -247,6 +247,56 @@ display:
           separator: ', '
           field_api_classes: false
           plugin_id: field
+        site_environment_status:
+          id: site_environment_status
+          table: node_field_data
+          field: site_environment_status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Environment Status'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          entity_type: node
+          plugin_id: site_environment_status
         operations:
           id: operations
           table: node

--- a/web/modules/custom/shepherd/shp_custom/src/Service/Site.php
+++ b/web/modules/custom/shepherd/shp_custom/src/Service/Site.php
@@ -2,9 +2,6 @@
 
 namespace Drupal\shp_custom\Service;
 
-use Drupal\Core\Ajax\AjaxResponse;
-use Drupal\Core\Ajax\HtmlCommand;
-use Drupal\Core\Ajax\InvokeCommand;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\DependencyInjection\DependencySerializationTrait;
 use Drupal\Core\Entity\EntityTypeManagerInterface;

--- a/web/modules/custom/shepherd/shp_orchestration/shp_orchestration.services.yml
+++ b/web/modules/custom/shepherd/shp_orchestration/shp_orchestration.services.yml
@@ -20,3 +20,6 @@ services:
   shp_orchestration.environment:
     class: Drupal\shp_orchestration\Service\Environment
     arguments: ['@plugin.manager.orchestration_provider', '@shp_orchestration.configuration', '@shp_custom.environment', '@shp_custom.site']
+  shp_orchestration.status:
+    class: Drupal\shp_orchestration\Service\Status
+    arguments: ['@plugin.manager.orchestration_provider' ]

--- a/web/modules/custom/shepherd/shp_orchestration/shp_orchestration.services.yml
+++ b/web/modules/custom/shepherd/shp_orchestration/shp_orchestration.services.yml
@@ -22,4 +22,4 @@ services:
     arguments: ['@plugin.manager.orchestration_provider', '@shp_orchestration.configuration', '@shp_custom.environment', '@shp_custom.site']
   shp_orchestration.status:
     class: Drupal\shp_orchestration\Service\Status
-    arguments: ['@plugin.manager.orchestration_provider' ]
+    arguments: ['@plugin.manager.orchestration_provider','@shp_custom.environment', '@shp_custom.site']

--- a/web/modules/custom/shepherd/shp_orchestration/src/OrchestrationProviderInterface.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/OrchestrationProviderInterface.php
@@ -366,6 +366,25 @@ interface OrchestrationProviderInterface extends PluginInspectionInterface {
   public function getSiteEnvironmentsStatus(string $site_id);
 
   /**
+   * Get the status of a given environment.
+   *
+   * @param string $project_name
+   *   Name of the project.
+   * @param string $short_name
+   *   Short name of the site.
+   * @param string $environment_id
+   *   Environment node id.
+   *
+   * @return array|bool
+   *   Returns the given environment status, or false.
+   */
+  public function getEnvironmentStatus(
+    string $project_name,
+    string $short_name,
+    string $environment_id
+  );
+
+  /**
    * Retrieves the url for a given environment.
    *
    * @param string $project_name

--- a/web/modules/custom/shepherd/shp_orchestration/src/Plugin/OrchestrationProvider/OpenShiftOrchestrationProvider.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/Plugin/OrchestrationProvider/OpenShiftOrchestrationProvider.php
@@ -611,6 +611,29 @@ class OpenShiftOrchestrationProvider extends OrchestrationProviderBase {
   /**
    * {@inheritdoc}
    */
+  public function getEnvironmentStatus(string $project_name, string $short_name, string $environment_id) {
+
+    $deployment_name = self::generateDeploymentName(
+      $project_name,
+      $short_name,
+      $environment_id
+    );
+
+    try {
+      $deploymentConfig = $this->client->getDeploymentConfig($deployment_name);
+      $test = '';
+      // process this and maybe extract the method out somehow.
+      return $deploymentConfig;
+    }
+    catch (ClientException $e) {
+      $this->handleClientException($e);
+      return FALSE;
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getEnvironmentUrl(string $project_name, string $short_name, string $environment_id) {
     $deployment_name = self::generateDeploymentName(
       $project_name,

--- a/web/modules/custom/shepherd/shp_orchestration/src/Service/Environment.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/Service/Environment.php
@@ -24,16 +24,22 @@ class Environment extends EntityActionBase {
   protected $configuration;
 
   /**
+   * Orchestration Provider Manager.
+   *
    * @var \Drupal\shp_orchestration\OrchestrationProviderPluginManager
    */
   private $orchestrationProviderPluginManager;
 
   /**
+   * Environment service.
+   *
    * @var \Drupal\shp_custom\Service\Environment|\Drupal\shp_orchestration\Service\Environment
    */
   private $environmentEntity;
 
   /**
+   * Site service.
+   *
    * @var \Drupal\shp_custom\Service\Site
    */
   private $siteEntity;
@@ -42,9 +48,13 @@ class Environment extends EntityActionBase {
    * Shepherd constructor.
    *
    * @param \Drupal\shp_orchestration\OrchestrationProviderPluginManager $orchestrationProviderPluginManager
+   *   Orchestration provider manager.
    * @param \Drupal\shp_orchestration\Service\Configuration $configuration
+   *   Configuration service.
    * @param \Drupal\shp_custom\Service\Environment $environment
+   *   Environment service.
    * @param \Drupal\shp_custom\Service\Site $site
+   *   Site service.
    */
   public function __construct(OrchestrationProviderPluginManager $orchestrationProviderPluginManager, Configuration $configuration, EnvironmentEntity $environment, SiteEntity $site) {
     parent::__construct($orchestrationProviderPluginManager);
@@ -56,7 +66,10 @@ class Environment extends EntityActionBase {
   /**
    * Tell the active orchestration provider an environment was created.
    *
+   * @todo - Extract some of the logic out of this method, too large.
+   *
    * @param \Drupal\node\NodeInterface $node
+   *   Node entity.
    *
    * @return bool
    */
@@ -158,6 +171,7 @@ class Environment extends EntityActionBase {
    * Tell the active orchestration provider an environment was updated.
    *
    * @param \Drupal\node\NodeInterface $node
+   *   Node entity.
    *
    * @return bool
    */
@@ -170,6 +184,7 @@ class Environment extends EntityActionBase {
    * Tell the active orchestration provider an environment was deleted.
    *
    * @param \Drupal\node\NodeInterface $node
+   *   Node entity.
    *
    * @return bool
    */
@@ -201,10 +216,16 @@ class Environment extends EntityActionBase {
   }
 
   /**
+   * Tell the active orchestration provider an environment was promoted.
+   *
    * @param \Drupal\node\NodeInterface $site
+   *   Site entity.
    * @param \Drupal\node\NodeInterface $environment
+   *   Environment entity.
    * @param bool $exclusive
+   *   Exclusive.
    * @param bool $clear_cache
+   *   Clear cache.
    *
    * @return bool
    */
@@ -225,7 +246,7 @@ class Environment extends EntityActionBase {
 
     // @todo everything is exclusive for now, implement non-exclusive?
 
-    // Load a non protected term
+    // Load a non protected term.
     // @todo handle multiples? this is quite horrid.
     $ids = \Drupal::entityQuery('taxonomy_term')
       ->condition('vid', 'shp_environment_types')
@@ -240,7 +261,7 @@ class Environment extends EntityActionBase {
       ->execute();
     $promoted_term = reset(Term::loadMultiple($ids));
 
-    // Demote all current prod environments
+    // Demote all current prod environments.
     $old_promoted = \Drupal::entityQuery('node')
       ->condition('field_shp_environment_type', $promoted_term->id())
       ->condition('nid', $environment->id(), '<>')
@@ -251,7 +272,7 @@ class Environment extends EntityActionBase {
       $node->save();
     }
 
-    // Finally Update the environment that was promoted if we need to
+    // Finally Update the environment that was promoted if we need to.
     if ($environment->field_shp_environment_type->target_id != $promoted_term->id()) {
       $environment->field_shp_environment_type = [['target_id' => $promoted_term->id()]];
       $environment->save();

--- a/web/modules/custom/shepherd/shp_orchestration/src/Service/Status.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/Service/Status.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Drupal\shp_orchestration\Service;
+
+use Drupal\node\NodeInterface;
+use Drupal\shp_orchestration\OrchestrationProviderPluginManager;
+use Drupal\shp_orchestration\Exception\OrchestrationProviderNotConfiguredException;
+
+/**
+ * Class Status.
+ *
+ * @package Drupal\shp_orchestration\Service
+ */
+class Status {
+
+  /**
+   * The currently active orchestration provider plugin.
+   *
+   * @var \Drupal\shp_orchestration\OrchestrationProviderInterface
+   */
+  protected $orchestrationProviderPlugin;
+
+  /**
+   * Status constructor.
+   *
+   * @param \Drupal\shp_orchestration\OrchestrationProviderPluginManager $orchestrationProviderPluginManager
+   *   The orchestration provider manager.
+   */
+  public function __construct(OrchestrationProviderPluginManager $orchestrationProviderPluginManager) {
+    try {
+      $this->orchestrationProviderPlugin = $orchestrationProviderPluginManager->getProviderInstance();
+    }
+    catch (OrchestrationProviderNotConfiguredException $e) {
+      drupal_set_message($e->getMessage(), 'warning');
+    }
+  }
+
+  /**
+   * Retrieves site environments status via orchestrationProvider.
+   *
+   * @param \Drupal\node\NodeInterface $site
+   *   The site node entity.
+   *
+   * @return array
+   *   All environment statuses.
+   */
+  public function get(NodeInterface $site) {
+    return $this->orchestrationProviderPlugin->getSiteEnvironmentsStatus($site->id());
+  }
+
+}

--- a/web/modules/custom/shepherd/shp_orchestration/src/Service/Status.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/Service/Status.php
@@ -3,6 +3,8 @@
 namespace Drupal\shp_orchestration\Service;
 
 use Drupal\node\NodeInterface;
+use Drupal\shp_custom\Service\Environment as EnvironmentEntity;
+use Drupal\shp_custom\Service\Site as SiteEntity;
 use Drupal\shp_orchestration\OrchestrationProviderPluginManager;
 use Drupal\shp_orchestration\Exception\OrchestrationProviderNotConfiguredException;
 
@@ -21,31 +23,54 @@ class Status {
   protected $orchestrationProviderPlugin;
 
   /**
+   * Environment service.
+   *
+   * @var \Drupal\shp_custom\Service\Environment|\Drupal\shp_orchestration\Service\Environment
+   */
+  protected $environmentEntity;
+
+  /**
+   * Site service.
+   *
+   * @var \Drupal\shp_custom\Service\Site
+   */
+  protected $siteEntity;
+
+  /**
    * Status constructor.
    *
    * @param \Drupal\shp_orchestration\OrchestrationProviderPluginManager $orchestrationProviderPluginManager
    *   The orchestration provider manager.
+   * @param \Drupal\shp_custom\Service\Environment $environment
+   *   Environment service.
+   * @param \Drupal\shp_custom\Service\Site $site
+   *   Site service.
    */
-  public function __construct(OrchestrationProviderPluginManager $orchestrationProviderPluginManager) {
+  public function __construct(OrchestrationProviderPluginManager $orchestrationProviderPluginManager, EnvironmentEntity $environment, SiteEntity $site) {
     try {
       $this->orchestrationProviderPlugin = $orchestrationProviderPluginManager->getProviderInstance();
     }
     catch (OrchestrationProviderNotConfiguredException $e) {
       drupal_set_message($e->getMessage(), 'warning');
     }
+
+    $this->environmentEntity = $environment;
+    $this->siteEntity = $site;
   }
 
   /**
    * Retrieves site environments status via orchestrationProvider.
    *
-   * @param \Drupal\node\NodeInterface $site
+   * @param \Drupal\node\NodeInterface $environment
    *   The site node entity.
    *
    * @return array
    *   All environment statuses.
    */
-  public function get(NodeInterface $site) {
-    return $this->orchestrationProviderPlugin->getSiteEnvironmentsStatus($site->id());
+  public function get(NodeInterface $environment) {
+    $site = $this->environmentEntity->getSite($environment);
+    $project = $this->siteEntity->getProject($site);
+    return $this->orchestrationProviderPlugin->getEnvironmentStatus($project->getTitle(), $site->field_shp_short_name->valie, $environment->id());
   }
 
 }

--- a/web/modules/custom/shepherd/shp_orchestration/src/Service/Status.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/Service/Status.php
@@ -70,7 +70,7 @@ class Status {
   public function get(NodeInterface $environment) {
     $site = $this->environmentEntity->getSite($environment);
     $project = $this->siteEntity->getProject($site);
-    return $this->orchestrationProviderPlugin->getEnvironmentStatus($project->getTitle(), $site->field_shp_short_name->valie, $environment->id());
+    return $this->orchestrationProviderPlugin->getEnvironmentStatus($project->getTitle(), $site->field_shp_short_name->value, $environment->id());
   }
 
 }


### PR DESCRIPTION
Add views field plugin for sites environment view that displays the status of an environment in simple terms : `running`, `stopped`, `failed`, `building`. Previously we achieved this using vuejs and a custom way of loading the view, this time around we are avoiding the complexity and just using the views plugin normally - in short : no dynamic updates of status. 