### PR TITLE
Add destination parameter to operations links if its not already there.

### DIFF
--- a/web/modules/custom/shepherd/shp_custom/src/Service/Environment.php
+++ b/web/modules/custom/shepherd/shp_custom/src/Service/Environment.php
@@ -283,6 +283,14 @@ class Environment {
         'url'       => $logs,
       ];
     }
+
+    // Process copied from getDefaultOperations()
+    $destination = $this->currentRequest->getRequestUri();
+    foreach ($operations as $key => $operation) {
+      if (!isset($operations[$key]['query'])) {
+        $operations[$key]['query'] = ['destination' => $destination];
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Implement a mechanism like /home/simon/projects/uni_gpl/shepherd/web/core/modules/node/src/NodeListBuilder.php uses for the default operations destinations.