### PR TITLE
Feature/webops 287 fix deployment name limit characters

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1433,8 +1433,7 @@
                         "status": "not-covered",
                         "message": "Project has not opted into security advisory coverage!"
                     }
-                },
-                "patches_applied": []
+                }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
@@ -1454,7 +1453,8 @@
             "homepage": "https://www.drupal.org/project/key_value_field",
             "support": {
                 "source": "http://cgit.drupalcode.org/key_value_field"
-            }
+            },
+            "time": "2018-02-02T18:05:22+00:00"
         },
         {
             "name": "drupal/log_stdout",
@@ -4882,12 +4882,6 @@
                 "type": "git",
                 "url": "https://git.drupal.org/project/coder.git",
                 "reference": "984c54a7b1e8f27ff1c32348df69712afd86b17f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/klausi/coder/zipball/984c54a7b1e8f27ff1c32348df69712afd86b17f",
-                "reference": "984c54a7b1e8f27ff1c32348df69712afd86b17f",
-                "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",

--- a/web/modules/custom/shepherd/shp_database_provisioner/shp_database_provisioner.module
+++ b/web/modules/custom/shepherd/shp_database_provisioner/shp_database_provisioner.module
@@ -41,8 +41,6 @@ function shp_database_provisioner_node_insert(EntityInterface $entity) {
     }
 
     $deployment_name = $orchestration_provider_plugin::generateDeploymentName(
-      $project->getTitle(),
-      $site->field_shp_short_name->value,
       $entity->id()
     );
 

--- a/web/modules/custom/shepherd/shp_orchestration/src/OrchestrationProviderBase.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/OrchestrationProviderBase.php
@@ -80,7 +80,7 @@ abstract class OrchestrationProviderBase extends PluginBase implements Container
   /**
    * {@inheritdoc}
    */
-  public static function generateDeploymentName(int $id) {
+  public static function generateDeploymentName(string $id) {
     return 'env-' . $id;
   }
 

--- a/web/modules/custom/shepherd/shp_orchestration/src/OrchestrationProviderBase.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/OrchestrationProviderBase.php
@@ -80,16 +80,8 @@ abstract class OrchestrationProviderBase extends PluginBase implements Container
   /**
    * {@inheritdoc}
    */
-  public static function generateDeploymentName(
-    string $project_name,
-    string $short_name,
-    int $id
-  ) {
-    return implode('-', [
-      self::sanitise($project_name),
-      self::sanitise($short_name),
-      $id,
-    ]);
+  public static function generateDeploymentName(int $id) {
+    return 'env-' . $id;
   }
 
   /**

--- a/web/modules/custom/shepherd/shp_orchestration/src/OrchestrationProviderInterface.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/OrchestrationProviderInterface.php
@@ -335,23 +335,15 @@ interface OrchestrationProviderInterface extends PluginInspectionInterface {
   public function updateSecret(string $name, array $data);
 
   /**
-   * Generates a deployment name from Shepherd entities.
+   * Generates a deployment name from Shepherd node id.
    *
-   * @param string $project_name
-   *   Name of the project.
-   * @param string $short_name
-   *   Short name of the site.
    * @param int $id
    *   Id of the name to be generated.
    *
    * @return string
    *   Returns the generated deployment name.
    */
-  public static function generateDeploymentName(
-    string $project_name,
-    string $short_name,
-    int $id
-  );
+  public static function generateDeploymentName(int $id);
 
   /**
    * Get the status of a collection of environments related to a site.

--- a/web/modules/custom/shepherd/shp_orchestration/src/OrchestrationProviderInterface.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/OrchestrationProviderInterface.php
@@ -337,13 +337,13 @@ interface OrchestrationProviderInterface extends PluginInspectionInterface {
   /**
    * Generates a deployment name from Shepherd node id.
    *
-   * @param int $id
+   * @param string $id
    *   Id of the name to be generated.
    *
    * @return string
    *   Returns the generated deployment name.
    */
-  public static function generateDeploymentName(int $id);
+  public static function generateDeploymentName(string $id);
 
   /**
    * Get the status of a collection of environments related to a site.

--- a/web/modules/custom/shepherd/shp_orchestration/src/Plugin/OrchestrationProvider/OpenShiftOrchestrationProvider.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/Plugin/OrchestrationProvider/OpenShiftOrchestrationProvider.php
@@ -168,11 +168,7 @@ class OpenShiftOrchestrationProvider extends OrchestrationProviderBase {
 
     $sanitised_project_name = self::sanitise($project_name);
     $sanitised_source_ref = self::sanitise($source_ref);
-    $deployment_name = self::generateDeploymentName(
-      $project_name,
-      $short_name,
-      $environment_id
-    );
+    $deployment_name = self::generateDeploymentName($environment_id);
     $image_stream_tag = $sanitised_project_name . ':' . $sanitised_source_ref;
     $build_config_name = $sanitised_project_name . '-' . $sanitised_source_ref;
     $formatted_env_vars = $this->formatEnvVars($environment_variables, $deployment_name);
@@ -292,11 +288,7 @@ class OpenShiftOrchestrationProvider extends OrchestrationProviderBase {
     string $short_name,
     string $environment_id
   ) {
-    $deployment_name = self::generateDeploymentName(
-      $project_name,
-      $short_name,
-      $environment_id
-    );
+    $deployment_name = self::generateDeploymentName($environment_id);
 
     try {
       // @todo are we doing this?
@@ -350,17 +342,9 @@ class OpenShiftOrchestrationProvider extends OrchestrationProviderBase {
     string $source_ref = 'master',
     bool $clear_cache = TRUE
   ) {
-    $site_deployment_name = self::generateDeploymentName(
-      $project_name,
-      $short_name,
-      $site_id
-    );
+    $site_deployment_name = self::generateDeploymentName($site_id);
 
-    $environment_deployment_name = self::generateDeploymentName(
-      $project_name,
-      $short_name,
-      $environment_id
-    );
+    $environment_deployment_name = self::generateDeploymentName($environment_id);
 
     $result = $this->client->updateService($site_deployment_name, $environment_deployment_name);
     if ($result && $clear_cache) {
@@ -387,11 +371,8 @@ class OpenShiftOrchestrationProvider extends OrchestrationProviderBase {
     string $domain,
     string $path
   ) {
-    $deployment_name = self::generateDeploymentName(
-      $project_name,
-      $short_name,
-      $site_id
-    );
+    $deployment_name = self::generateDeploymentName($site_id);
+
     // @todo - make port a var and great .. so great .. yuge!
     $port = 8080;
     try {
@@ -419,11 +400,7 @@ class OpenShiftOrchestrationProvider extends OrchestrationProviderBase {
     string $short_name,
     int $site_id
   ) {
-    $deployment_name = self::generateDeploymentName(
-      $project_name,
-      $short_name,
-      $site_id
-    );
+    $deployment_name = self::generateDeploymentName($site_id);
 
     $this->client->deleteService($deployment_name);
     $this->client->deleteRoute($deployment_name);
@@ -482,11 +459,7 @@ class OpenShiftOrchestrationProvider extends OrchestrationProviderBase {
     string $commands = ''
   ) {
     $sanitised_project_name = self::sanitise($project_name);
-    $deployment_name = self::generateDeploymentName(
-      $project_name,
-      $short_name,
-      $environment_id
-    );
+    $deployment_name = self::generateDeploymentName($environment_id);
 
     // Retrieve existing deployment details to use where possible.
     $deployment_config = $this->client->getDeploymentConfig($deployment_name);
@@ -607,11 +580,7 @@ class OpenShiftOrchestrationProvider extends OrchestrationProviderBase {
    */
   public function getEnvironmentStatus(string $project_name, string $short_name, string $environment_id) {
 
-    $deployment_name = self::generateDeploymentName(
-      $project_name,
-      $short_name,
-      $environment_id
-    );
+    $deployment_name = self::generateDeploymentName($environment_id);
 
     try {
       $deployment_config = $this->client->getDeploymentConfig($deployment_name);
@@ -652,11 +621,7 @@ class OpenShiftOrchestrationProvider extends OrchestrationProviderBase {
    * {@inheritdoc}
    */
   public function getEnvironmentUrl(string $project_name, string $short_name, string $environment_id) {
-    $deployment_name = self::generateDeploymentName(
-      $project_name,
-      $short_name,
-      $environment_id
-    );
+    $deployment_name = self::generateDeploymentName($environment_id);
 
     try {
       $route = $this->client->getRoute($deployment_name);
@@ -675,11 +640,7 @@ class OpenShiftOrchestrationProvider extends OrchestrationProviderBase {
    * {@inheritdoc}
    */
   public function getTerminalUrl(string $project_name, string $short_name, string $environment_id) {
-    $deployment_name = self::generateDeploymentName(
-      $project_name,
-      $short_name,
-      $environment_id
-    );
+    $deployment_name = self::generateDeploymentName($environment_id);
 
     try {
       $pods = $this->client->getPod('', 'app=' . $deployment_name . ',environment_id=' . $environment_id);
@@ -706,11 +667,7 @@ class OpenShiftOrchestrationProvider extends OrchestrationProviderBase {
    * {@inheritdoc}
    */
   public function getLogUrl(string $project_name, string $short_name, string $environment_id) {
-    $deployment_name = self::generateDeploymentName(
-      $project_name,
-      $short_name,
-      $environment_id
-    );
+    $deployment_name = self::generateDeploymentName($environment_id);
 
     try {
       $pods = $this->client->getPod('', 'app=' . $deployment_name . ',environment_id=' . $environment_id);

--- a/web/modules/custom/shepherd/shp_orchestration/src/Service/Environment.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/Service/Environment.php
@@ -96,11 +96,7 @@ class Environment extends EntityActionBase {
       $cron_jobs[$job->key] = $job->value;
     }
 
-    $deployment_name = $this->orchestrationProviderPlugin::generateDeploymentName(
-      $project->getTitle(),
-      $site->field_shp_short_name->value,
-      $node->id()
-    );
+    $deployment_name = $this->orchestrationProviderPlugin::generateDeploymentName($node->id());
 
     // Generate an auth token and add it to the secret associated with the
     // environment. Create the secret if it doesn't exist.


### PR DESCRIPTION
Openshift has a 64 character limit on the name of a deployment config + it prepends and appends additional information like the timestamp and the Openshift project name. This leaves us with little room for unique names, previously we used {project_name}-{short_name}-{nid}. If the site or project have a long title things break. 

Node ids are constant, unique and small, so opted to just use them. 