### PR TITLE
Feature/orchestration exception

### DIFF
--- a/web/modules/custom/shepherd/shp_backup/src/Service/Backup.php
+++ b/web/modules/custom/shepherd/shp_backup/src/Service/Backup.php
@@ -10,7 +10,6 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
-use Drupal\shp_orchestration\Exception\OrchestrationProviderNotConfiguredException;
 use Drupal\shp_orchestration\OrchestrationProviderPluginManagerInterface;
 use Drupal\shp_orchestration\Service\ActiveJobManager;
 use Drupal\taxonomy\Entity\Term;
@@ -88,13 +87,7 @@ class Backup {
     $this->token = $token;
     $this->entityTypeManager = $entityTypeManager;
     $this->activeJobManager = $activeJobManager;
-
-    try {
-      $this->orchestrationProvider = $pluginManager->getProviderInstance();
-    }
-    catch (OrchestrationProviderNotConfiguredException $e) {
-      drupal_set_message($e->getMessage(), 'warning');
-    }
+    $this->orchestrationProvider = $pluginManager->getProviderInstance();
   }
 
   /**

--- a/web/modules/custom/shepherd/shp_custom/shp_custom.module
+++ b/web/modules/custom/shepherd/shp_custom/shp_custom.module
@@ -87,30 +87,6 @@ function shp_custom_toolbar_alter(&$items) {
 }
 
 /**
- * Generate a list of projects for a select list.
- *
- * @todo No longer used, delete this.
- *
- * @return array
- *   The choices formatted as id => label.
- */
-function shp_custom_projects() {
-  $ids = \Drupal::entityQuery('node')
-    ->condition('type', 'shp_project')
-    ->sort('title', 'ASC')
-    ->execute();
-
-  $entities = Node::loadMultiple($ids);
-
-  $choices = [];
-  foreach ($entities as $entity) {
-    $choices[$entity->id()] = $entity->getTitle();
-  }
-
-  return $choices;
-}
-
-/**
  * Invalidate site entity caches because environments for sites have changed.
  *
  * @param Drupal\node\NodeInterface $environment
@@ -147,7 +123,7 @@ function shp_custom_node_update(NodeInterface $node) {
           if ($environment->moderation_state->value != 'archived') {
 
             // Create the backup node and perform a backup.
-            $backup->createBackupNode($node, $environment, NULL, TRUE);
+            $backup->createNode($environment);
 
             // @todo Shepherd: Need to queue to enable this part.
             //if (!$result = $orchestration_provider_plugin->archivedEnvironment($entity->id())) {
@@ -159,14 +135,13 @@ function shp_custom_node_update(NodeInterface $node) {
       break;
 
     case 'shp_environment':
-      if ($node->moderation_state->value == 'archived') {
+      if ($node->moderation_state->value === 'archived') {
         $backup = \Drupal::service('shp_backup.backup');
-        $site = Node::load($node->field_shp_site->target_id);
 
         // Create the backup node and perform a backup.
-        $backup->createBackupNode($site, $node, NULL, TRUE);
+        $backup->createNode($node);
 
-        // @todo Shepherd: Need to queue to enable this part.
+        // @todo Shepherd: Need to queue to enable this part. I.e. backup must complete first.
         //$result = $orchestration_provider_plugin->archivedEnvironment($entity->id());
         shp_custom_invalidate_site_cache($node);
       }

--- a/web/modules/custom/shepherd/shp_custom/shp_custom.module
+++ b/web/modules/custom/shepherd/shp_custom/shp_custom.module
@@ -15,7 +15,6 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
-use Drupal\shp_orchestration\Exception\OrchestrationProviderNotConfiguredException;
 use Drupal\taxonomy\Entity\Term;
 
 /**
@@ -132,15 +131,9 @@ function shp_custom_invalidate_site_cache(NodeInterface $environment) {
 function shp_custom_node_update(NodeInterface $node) {
 
   if (strpos($node->bundle(), 'shp') !== FALSE) {
-    try {
-      /** @var Drupal\shp_orchestration\OrchestrationProviderInterface $orchestration_provider_plugin */
-      $orchestration_provider_plugin = \Drupal::service('plugin.manager.orchestration_provider')
-        ->getProviderInstance();
-    }
-    catch (OrchestrationProviderNotConfiguredException $e) {
-      drupal_set_message($e->getMessage(), 'warning');
-      return FALSE;
-    }
+    /** @var Drupal\shp_orchestration\OrchestrationProviderInterface $orchestration_provider_plugin */
+    $orchestration_provider_plugin = \Drupal::service('plugin.manager.orchestration_provider')
+      ->getProviderInstance();
   }
   else {
     return NULL;
@@ -176,7 +169,7 @@ function shp_custom_node_update(NodeInterface $node) {
         $backup = \Drupal::service('shp_backup.backup');
         $site = Node::load($node->field_shp_site->target_id);
 
-        // Create the backup node and perform a backup
+        // Create the backup node and perform a backup.
         $backup->createBackupNode($site, $node, NULL, TRUE);
 
         // @todo Shepherd: Need to queue to enable this part.

--- a/web/modules/custom/shepherd/shp_custom/shp_custom.module
+++ b/web/modules/custom/shepherd/shp_custom/shp_custom.module
@@ -129,13 +129,7 @@ function shp_custom_invalidate_site_cache(NodeInterface $environment) {
  * Triggers things when an instance's status is changed to archive.
  */
 function shp_custom_node_update(NodeInterface $node) {
-
-  if (strpos($node->bundle(), 'shp') !== FALSE) {
-    /** @var Drupal\shp_orchestration\OrchestrationProviderInterface $orchestration_provider_plugin */
-    $orchestration_provider_plugin = \Drupal::service('plugin.manager.orchestration_provider')
-      ->getProviderInstance();
-  }
-  else {
+  if (strpos($node->bundle(), 'shp') === FALSE) {
     return NULL;
   }
 

--- a/web/modules/custom/shepherd/shp_orchestration/config/install/shp_orchestration.settings.yml
+++ b/web/modules/custom/shepherd/shp_orchestration/config/install/shp_orchestration.settings.yml
@@ -1,2 +1,2 @@
-selected_provider: 'openshift_orchestration_provider'
+selected_provider: 'dummy_orchestration_provider'
 queued_operations: true

--- a/web/modules/custom/shepherd/shp_orchestration/shp_orchestration.install
+++ b/web/modules/custom/shepherd/shp_orchestration/shp_orchestration.install
@@ -27,6 +27,8 @@ function shp_orchestration_requirements($phase) {
           [':url' => (new Url('shp_orchestration.orchestration_provider.settings'))->toString()]),
       ];
     }
+
+    // @todo Implement check for specific provider config.
   }
   return $requirements;
 }

--- a/web/modules/custom/shepherd/shp_orchestration/shp_orchestration.install
+++ b/web/modules/custom/shepherd/shp_orchestration/shp_orchestration.install
@@ -20,10 +20,10 @@ function shp_orchestration_requirements($phase) {
 
     if ($selected_provider == 'dummy_orchestration_provider') {
       $requirements['orchestration_provider_not_configured'] = [
-        'title'       => t('Select and configure a functioning orchestration provider'),
+        'title'       => t('Select and configure an orchestration provider'),
         'value'       => t('Dummy provider selected.'),
         'severity'    => REQUIREMENT_WARNING,
-        'description' => t('A functioning provider must be selected and configured in order for Shepherd to control sites and environments. E.g. OpenShift. <a href=":url">Configure</a>',
+        'description' => t('A functioning provider must be selected and configured in order for Shepherd to control sites and environments. E.g. OpenShift. <a href=":url">Orchestration provider administration page</a>',
           [':url' => (new Url('shp_orchestration.orchestration_provider.settings'))->toString()]),
       ];
     }

--- a/web/modules/custom/shepherd/shp_orchestration/shp_orchestration.install
+++ b/web/modules/custom/shepherd/shp_orchestration/shp_orchestration.install
@@ -18,7 +18,7 @@ function shp_orchestration_requirements($phase) {
     $config_factory = \Drupal::service('config.factory');
     $selected_provider = $config_factory->get('shp_orchestration.settings')->get('selected_provider');
 
-    if ($selected_provider == 'dummy_orchestration_provider') {
+    if ($selected_provider === 'dummy_orchestration_provider') {
       $requirements['orchestration_provider_not_configured'] = [
         'title'       => t('Select and configure an orchestration provider'),
         'value'       => t('Dummy provider selected.'),

--- a/web/modules/custom/shepherd/shp_orchestration/shp_orchestration.install
+++ b/web/modules/custom/shepherd/shp_orchestration/shp_orchestration.install
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the shp_orchestration module.
+ */
+
+use Drupal\Core\Url;
+
+/**
+ * Implements hook_requirements().
+ */
+function shp_orchestration_requirements($phase) {
+  $requirements = [];
+
+  if ($phase == 'runtime') {
+    // @todo check the selected provider.
+    $config_factory = \Drupal::service('config.factory');
+    $selected_provider = $config_factory->get('shp_orchestration.settings')->get('selected_provider');
+
+    if ($selected_provider == 'dummy_orchestration_provider') {
+      $requirements['orchestration_provider_not_configured'] = [
+        'title'       => t('Select and configure a functioning orchestration provider'),
+        'value'       => t('Dummy provider selected.'),
+        'severity'    => REQUIREMENT_WARNING,
+        'description' => t('A functioning provider must be selected and configured in order for Shepherd to control sites and environments. E.g. OpenShift. <a href=":url">Configure</a>',
+          [':url' => (new Url('shp_orchestration.orchestration_provider.settings'))->toString()]),
+      ];
+    }
+  }
+  return $requirements;
+}

--- a/web/modules/custom/shepherd/shp_orchestration/shp_orchestration.module
+++ b/web/modules/custom/shepherd/shp_orchestration/shp_orchestration.module
@@ -7,7 +7,6 @@
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\node\NodeInterface;
-use Drupal\shp_orchestration\Exception\OrchestrationProviderNotConfiguredException;
 
 /**
  * Implements hook_ENTITY_TYPE_insert().
@@ -90,19 +89,14 @@ function shp_orchestration_shp_project_form_validate(array $form, FormStateInter
   // Verify that the secret exists in OpenShift.
   $secret_name = $form_state->getValue('field_shp_build_secret')[0]['value'];
 
-  try {
-    /** @var Drupal\shp_orchestration\OrchestrationProviderInterface $orchestration_provider_plugin */
-    $orchestration_provider_plugin = \Drupal::service('plugin.manager.orchestration_provider')
-      ->getProviderInstance();
+  /** @var Drupal\shp_orchestration\OrchestrationProviderInterface $orchestration_provider_plugin */
+  $orchestration_provider_plugin = \Drupal::service('plugin.manager.orchestration_provider')
+    ->getProviderInstance();
 
-    $response = $orchestration_provider_plugin->getSecret($secret_name);
-    // The client will respond FALSE if the status code doesn't return a 200.
-    if ($response === FALSE) {
-      $form_state->setErrorByName('field_shp_build_secret', t('Secret: @secret_name does not exist.', ['@secret_name' => $secret_name]));
-    }
-  }
-  catch (OrchestrationProviderNotConfiguredException $e) {
-    drupal_set_message($e->getMessage(), 'warning');
+  $response = $orchestration_provider_plugin->getSecret($secret_name);
+  // The client will respond FALSE if the status code doesn't return a 200.
+  if ($response === FALSE) {
+    $form_state->setErrorByName('field_shp_build_secret', t('Secret: @secret_name does not exist.', ['@secret_name' => $secret_name]));
   }
 }
 

--- a/web/modules/custom/shepherd/shp_orchestration/src/Exception/OrchestrationProviderNotConfiguredException.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/Exception/OrchestrationProviderNotConfiguredException.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Drupal\shp_orchestration\Exception;
-
-/**
- * Orchestration provider not configured exception.
- */
-class OrchestrationProviderNotConfiguredException extends \Exception {}

--- a/web/modules/custom/shepherd/shp_orchestration/src/OrchestrationProviderBase.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/OrchestrationProviderBase.php
@@ -6,7 +6,6 @@ use Drupal\Component\Plugin\PluginBase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
-use Drupal\shp_orchestration\Exception\OrchestrationProviderNotConfiguredException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -34,8 +33,6 @@ abstract class OrchestrationProviderBase extends PluginBase implements Container
    *   Plugin definition.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   Entity Type Manager service.
-   *
-   * @throws \Drupal\shp_orchestration\Exception\OrchestrationProviderNotConfiguredException
    */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
@@ -43,11 +40,6 @@ abstract class OrchestrationProviderBase extends PluginBase implements Container
     $config_entity_id = $plugin_definition['config_entity_id'];
     $entity_manager = $this->entityTypeManager->getStorage($config_entity_id);
     $this->configEntity = $entity_manager->load($config_entity_id);
-    if (!is_object($this->configEntity)) {
-      throw new OrchestrationProviderNotConfiguredException(
-        'Orchestration provider is not configured. Changes made in Shepherd will not be reflected in backend until this is completed.'
-      );
-    }
   }
 
   /**

--- a/web/modules/custom/shepherd/shp_orchestration/src/Plugin/OrchestrationProvider/DummyOrchestrationProvider.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/Plugin/OrchestrationProvider/DummyOrchestrationProvider.php
@@ -25,14 +25,14 @@ class DummyOrchestrationProvider extends OrchestrationProviderBase {
   /**
    * {@inheritdoc}
    */
-  public function createdProject(string $name, string $builder_image, string $source_repo, string $source_ref = 'master', string $source_secret = NULL) {
+  public function createdProject(string $name, string $builder_image, string $source_repo, string $source_ref = 'master', string $source_secret = NULL, array $environment_variables = []) {
     return TRUE;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function updatedProject(string $name, string $builder_image, string $source_repo, string $source_ref = 'master', string $source_secret = NULL) {
+  public function updatedProject(string $name, string $builder_image, string $source_repo, string $source_ref = 'master', string $source_secret = '', array $environment_variables = []) {
     return TRUE;
   }
 
@@ -60,6 +60,7 @@ class DummyOrchestrationProvider extends OrchestrationProviderBase {
     string $source_secret = NULL,
     string $storage_class = '',
     bool $update_on_image_change = FALSE,
+    bool $cron_suspended = FALSE,
     array $environment_variables = [],
     array $secrets = [],
     array $probes = [],
@@ -83,6 +84,8 @@ class DummyOrchestrationProvider extends OrchestrationProviderBase {
     string $source_repo,
     string $source_ref = 'master',
     string $source_secret = NULL,
+    bool $update_on_image_change = FALSE,
+    bool $cron_suspended = FALSE,
     array $environment_variables = [],
     array $secrets = [],
     array $probes = [],
@@ -232,11 +235,7 @@ class DummyOrchestrationProvider extends OrchestrationProviderBase {
   /**
    * {@inheritdoc}
    */
-  public static function generateDeploymentName(
-    string $project_name,
-    string $short_name,
-    int $id
-  ) {
+  public static function generateDeploymentName(string $id) {
     return 'deployment_name';
   }
 
@@ -278,6 +277,13 @@ class DummyOrchestrationProvider extends OrchestrationProviderBase {
    */
   public function getLogUrl(string $project_name, string $short_name, string $environment_id) {
     return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getEnvironmentStatus(string $project_name, string $short_name, string $environment_id) {
+    return FALSE;
   }
 
 }

--- a/web/modules/custom/shepherd/shp_orchestration/src/Service/EntityActionBase.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/Service/EntityActionBase.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\shp_orchestration\Service;
 
-use Drupal\shp_orchestration\Exception\OrchestrationProviderNotConfiguredException;
 use Drupal\shp_orchestration\OrchestrationProviderPluginManager;
 
 /**
@@ -23,12 +22,7 @@ class EntityActionBase {
    *   The orchestration provider manager.
    */
   public function __construct(OrchestrationProviderPluginManager $orchestrationProviderPluginManager) {
-    try {
-      $this->orchestrationProviderPlugin = $orchestrationProviderPluginManager->getProviderInstance();
-    }
-    catch (OrchestrationProviderNotConfiguredException $e) {
-      drupal_set_message($e->getMessage(), 'warning');
-    }
+    $this->orchestrationProviderPlugin = $orchestrationProviderPluginManager->getProviderInstance();
   }
 
 }

--- a/web/modules/custom/shepherd/shp_orchestration/src/Service/Status.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/Service/Status.php
@@ -6,7 +6,6 @@ use Drupal\node\NodeInterface;
 use Drupal\shp_custom\Service\Environment as EnvironmentEntity;
 use Drupal\shp_custom\Service\Site as SiteEntity;
 use Drupal\shp_orchestration\OrchestrationProviderPluginManager;
-use Drupal\shp_orchestration\Exception\OrchestrationProviderNotConfiguredException;
 
 /**
  * Class Status.
@@ -47,13 +46,7 @@ class Status {
    *   Site service.
    */
   public function __construct(OrchestrationProviderPluginManager $orchestrationProviderPluginManager, EnvironmentEntity $environment, SiteEntity $site) {
-    try {
-      $this->orchestrationProviderPlugin = $orchestrationProviderPluginManager->getProviderInstance();
-    }
-    catch (OrchestrationProviderNotConfiguredException $e) {
-      drupal_set_message($e->getMessage(), 'warning');
-    }
-
+    $this->orchestrationProviderPlugin = $orchestrationProviderPluginManager->getProviderInstance();
     $this->environmentEntity = $environment;
     $this->siteEntity = $site;
   }


### PR DESCRIPTION
Incoming...

The orchestration provider not configured exception is evil. It's time to go and replace it with using the dummy provider as the default. We will warn users on the status page to configure and orchestration provider.

Reason(s) for doing this:
* Brittle.
* Causes exceptions at weird times - when there's dependencies that rely on being able to create the orchestration provider during install for example.
* Breaks dependency injection in some cases... so we took shortcuts to work around it using Drupal::service() directly (rather than DI).