### PR TITLE
Feature/webops 322 demote site envs

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5089,12 +5089,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/universityofadelaide/openshift-client.git",
-                "reference": "038c2daa443367f504efd35236b9e0436905fe3c"
+                "reference": "41a0275206475420b7cf17f16712046fceda8f73"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/universityofadelaide/openshift-client/zipball/038c2daa443367f504efd35236b9e0436905fe3c",
-                "reference": "038c2daa443367f504efd35236b9e0436905fe3c",
+                "url": "https://api.github.com/repos/universityofadelaide/openshift-client/zipball/41a0275206475420b7cf17f16712046fceda8f73",
+                "reference": "41a0275206475420b7cf17f16712046fceda8f73",
                 "shasum": ""
             },
             "require": {
@@ -5126,7 +5126,7 @@
                 }
             ],
             "description": "Simple OpenShift client for PHP.",
-            "time": "2018-08-01T01:56:15+00:00"
+            "time": "2018-08-01T05:32:16+00:00"
         },
         {
             "name": "universityofadelaide/shepherd-drupal-scaffold",

--- a/composer.lock
+++ b/composer.lock
@@ -5089,12 +5089,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/universityofadelaide/openshift-client.git",
-                "reference": "075562906065076c91f9976b4545dff854dde180"
+                "reference": "038c2daa443367f504efd35236b9e0436905fe3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/universityofadelaide/openshift-client/zipball/075562906065076c91f9976b4545dff854dde180",
-                "reference": "075562906065076c91f9976b4545dff854dde180",
+                "url": "https://api.github.com/repos/universityofadelaide/openshift-client/zipball/038c2daa443367f504efd35236b9e0436905fe3c",
+                "reference": "038c2daa443367f504efd35236b9e0436905fe3c",
                 "shasum": ""
             },
             "require": {
@@ -5126,7 +5126,7 @@
                 }
             ],
             "description": "Simple OpenShift client for PHP.",
-            "time": "2018-02-08T05:40:03+00:00"
+            "time": "2018-08-01T01:56:15+00:00"
         },
         {
             "name": "universityofadelaide/shepherd-drupal-scaffold",
@@ -5349,16 +5349,16 @@
         },
         {
             "name": "zendframework/zend-diactoros",
-            "version": "1.8.2",
+            "version": "1.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-diactoros.git",
-                "reference": "273c18bf6aaab20be9667a3aa4e7702e1e4e7ced"
+                "reference": "72c13834fb3db2a962e913758b384ff2e6425d6e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/273c18bf6aaab20be9667a3aa4e7702e1e4e7ced",
-                "reference": "273c18bf6aaab20be9667a3aa4e7702e1e4e7ced",
+                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/72c13834fb3db2a962e913758b384ff2e6425d6e",
+                "reference": "72c13834fb3db2a962e913758b384ff2e6425d6e",
                 "shasum": ""
             },
             "require": {
@@ -5371,7 +5371,7 @@
             "require-dev": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
-                "phpunit/phpunit": "^5.7.16 || ^6.0.8",
+                "phpunit/phpunit": "^5.7.16 || ^6.0.8 || ^7.2.7",
                 "zendframework/zend-coding-standard": "~1.0"
             },
             "type": "library",
@@ -5408,7 +5408,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2018-07-19T18:38:31+00:00"
+            "time": "2018-07-24T21:54:38+00:00"
         },
         {
             "name": "zendframework/zend-escaper",

--- a/web/modules/custom/shepherd/shp_orchestration/src/Plugin/OrchestrationProvider/OpenShiftOrchestrationProvider.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/Plugin/OrchestrationProvider/OpenShiftOrchestrationProvider.php
@@ -664,7 +664,7 @@ class OpenShiftOrchestrationProvider extends OrchestrationProviderBase {
       return FALSE;
     }
 
-    return $this->extractDeploymentConfigStatus($deployment_config);
+    return $deployment_config ? $this->extractDeploymentConfigStatus($deployment_config) : FALSE;
   }
 
   /**

--- a/web/modules/custom/shepherd/shp_orchestration/src/Service/Environment.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/Service/Environment.php
@@ -306,8 +306,9 @@ class Environment extends EntityActionBase {
       ->execute();
     $promoted_term = reset(Term::loadMultiple($ids));
 
-    // Demote all current prod environments.
+    // Demote all current prod environments - for this site!
     $old_promoted = \Drupal::entityQuery('node')
+      ->condition('field_shp_site', $site->id())
       ->condition('field_shp_environment_type', $promoted_term->id())
       ->condition('nid', $environment->id(), '<>')
       ->execute();


### PR DESCRIPTION
To test:
* Run robo dev:content-generate
* Create another environment for the default site.
* Create another separate test site and environment.
* Promote dev environments from both sites.
* Promote dev environment from a site with another prod environment.

Pass:
* Each site has at most 1 prod environment.
* Site A prod environment does not get demoted when Site B dev environment gets promoted.
* Site A prod environment gets demoted when Site A dev environment gets promoted.

Fail:
* Site A dev environment causes ALL other prod environments to get demoted to dev.