### PR TITLE
Feature/webops 321 imagestream dashes

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2137,17 +2137,17 @@
         },
         {
             "name": "drupal/r4032login",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupal.org/project/r4032login",
-                "reference": "8.x-1.0"
+                "reference": "8.x-1.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/r4032login-8.x-1.0.zip",
-                "reference": "8.x-1.0",
-                "shasum": "85ca96a4ff1ee3e3801dfc0bf8331127b4048f81"
+                "url": "https://ftp.drupal.org/files/projects/r4032login-8.x-1.1.zip",
+                "reference": "8.x-1.1",
+                "shasum": "dd9dc2daf8e4b960d2be1fe58e19a8ec4fbf30f1"
             },
             "require": {
                 "drupal/core": "~8.0"
@@ -2158,8 +2158,8 @@
                     "dev-1.x": "1.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-1.0",
-                    "datestamp": "1530773024",
+                    "version": "8.x-1.1",
+                    "datestamp": "1533913684",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -3397,20 +3397,22 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.9.6",
+            "version": "v0.9.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "4a2ce86f199d51b6e2524214dc06835e872f4fce"
+                "reference": "4f5b6c090948773a8bfeea6a0f07ab7d0b24e932"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/4a2ce86f199d51b6e2524214dc06835e872f4fce",
-                "reference": "4a2ce86f199d51b6e2524214dc06835e872f4fce",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/4f5b6c090948773a8bfeea6a0f07ab7d0b24e932",
+                "reference": "4f5b6c090948773a8bfeea6a0f07ab7d0b24e932",
                 "shasum": ""
             },
             "require": {
                 "dnoegel/php-xdg-base-dir": "0.1",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
                 "jakub-onderka/php-console-highlighter": "0.3.*",
                 "nikic/php-parser": "~1.3|~2.0|~3.0|~4.0",
                 "php": ">=5.4.0",
@@ -3465,7 +3467,7 @@
                 "interactive",
                 "shell"
             ],
-            "time": "2018-06-10T17:57:20+00:00"
+            "time": "2018-08-11T15:54:43+00:00"
         },
         {
             "name": "sebastian/version",
@@ -5092,12 +5094,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/universityofadelaide/openshift-client.git",
-                "reference": "41a0275206475420b7cf17f16712046fceda8f73"
+                "reference": "fa53c218049e50aaa06c98a431b006b9ee6e9419"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/universityofadelaide/openshift-client/zipball/41a0275206475420b7cf17f16712046fceda8f73",
-                "reference": "41a0275206475420b7cf17f16712046fceda8f73",
+                "url": "https://api.github.com/repos/universityofadelaide/openshift-client/zipball/fa53c218049e50aaa06c98a431b006b9ee6e9419",
+                "reference": "fa53c218049e50aaa06c98a431b006b9ee6e9419",
                 "shasum": ""
             },
             "require": {
@@ -5129,7 +5131,7 @@
                 }
             ],
             "description": "Simple OpenShift client for PHP.",
-            "time": "2018-08-01T05:32:16+00:00"
+            "time": "2018-08-15T12:20:55+00:00"
         },
         {
             "name": "universityofadelaide/shepherd-drupal-scaffold",
@@ -5352,16 +5354,16 @@
         },
         {
             "name": "zendframework/zend-diactoros",
-            "version": "1.8.4",
+            "version": "1.8.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-diactoros.git",
-                "reference": "736ffa7c2bfa4a60e8a10acb316fa2ac456c5fba"
+                "reference": "3e4edb822c942f37ade0d09579cfbab11e2fee87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/736ffa7c2bfa4a60e8a10acb316fa2ac456c5fba",
-                "reference": "736ffa7c2bfa4a60e8a10acb316fa2ac456c5fba",
+                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/3e4edb822c942f37ade0d09579cfbab11e2fee87",
+                "reference": "3e4edb822c942f37ade0d09579cfbab11e2fee87",
                 "shasum": ""
             },
             "require": {
@@ -5411,7 +5413,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2018-08-01T13:47:49+00:00"
+            "time": "2018-08-10T14:16:32+00:00"
         },
         {
             "name": "zendframework/zend-escaper",

--- a/web/modules/custom/shepherd/shp_orchestration/src/Plugin/OrchestrationProvider/OpenShiftOrchestrationProvider.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/Plugin/OrchestrationProvider/OpenShiftOrchestrationProvider.php
@@ -261,7 +261,7 @@ class OpenShiftOrchestrationProvider extends OrchestrationProviderBase {
     $image_stream = $this->client->getImageStream($sanitised_project_name);
     $this->createCronJobs(
       $deployment_name,
-      $source_ref,
+      $sanitised_source_ref,
       $cron_suspended,
       $cron_jobs,
       $image_stream,
@@ -533,6 +533,7 @@ class OpenShiftOrchestrationProvider extends OrchestrationProviderBase {
     string $commands = ''
   ) {
     $sanitised_project_name = self::sanitise($project_name);
+    $sanitised_source_ref = self::sanitise($source_ref);
     $deployment_name = self::generateDeploymentName($environment_id);
 
     // Retrieve existing deployment details to use where possible.
@@ -556,7 +557,7 @@ class OpenShiftOrchestrationProvider extends OrchestrationProviderBase {
     try {
       $response_body = $this->client->createJob(
         $deployment_name . '-' . $this->stringGenerator->generateRandomString(5),
-        $image_stream['status']['dockerImageRepository'] . ':' . $source_ref,
+        $image_stream['status']['dockerImageRepository'] . ':' . $sanitised_source_ref,
         $args_array,
         $volumes,
         $deploy_data
@@ -1038,6 +1039,7 @@ class OpenShiftOrchestrationProvider extends OrchestrationProviderBase {
    *   True on success.
    */
   protected function createCronJobs(string $deployment_name, string $source_ref, bool $cron_suspended, array $cron_jobs, array $image_stream, array $volumes, array $deploy_data) {
+    $sanitised_source_ref = self::sanitise($source_ref);
     foreach ($cron_jobs as $cron_job) {
       $args_array = [
         '/bin/sh',
@@ -1047,7 +1049,7 @@ class OpenShiftOrchestrationProvider extends OrchestrationProviderBase {
       try {
         $this->client->createCronJob(
           $deployment_name . '-' . $this->stringGenerator->generateRandomString(5),
-          $image_stream['status']['dockerImageRepository'] . ':' . $source_ref,
+          $image_stream['status']['dockerImageRepository'] . ':' . $sanitised_source_ref,
           $cron_job['schedule'],
           $cron_suspended,
           $args_array,

--- a/web/modules/custom/shepherd/shp_orchestration/tests/src/Unit/OrchestrationNamingTest.php
+++ b/web/modules/custom/shepherd/shp_orchestration/tests/src/Unit/OrchestrationNamingTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\Tests\shp_orchestration;
+
+use Drupal\shp_orchestration\OrchestrationProviderBase;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests the OrchestrationEvents class constants.
+ *
+ * @group shepherd
+ * @group shp_orchestration
+ *
+ * @coversDefaultClass \Drupal\shp_orchestration\OrchestrationProviderBase
+ */
+class OrchestrationNamingTest extends UnitTestCase {
+
+  /**
+   * Test the constants.
+   *
+   * @covers ::sanitise
+   *
+   * @dataProvider sanitizeInputData
+   */
+  public function testSanitize($input, $expected_output) {
+    $this->assertEquals($expected_output, OrchestrationProviderBase::sanitise($input));
+  }
+
+  /**
+   * Test input data for sanitize test.
+   */
+  public function sanitizeInputData() {
+    return [
+      ['ABC-123-fix-bug', 'abc-123-fix-bug'],
+      ['ABC-123-under_score', 'abc-123-under_score'],
+      ['feature/ABC-234-add-feature', 'feature-abc-234-add-feature'],
+    ];
+  }
+
+}

--- a/web/modules/custom/shepherd/shp_orchestration/tests/src/Unit/OrchestrationNamingTest.php
+++ b/web/modules/custom/shepherd/shp_orchestration/tests/src/Unit/OrchestrationNamingTest.php
@@ -20,16 +20,16 @@ class OrchestrationNamingTest extends UnitTestCase {
    *
    * @covers ::sanitise
    *
-   * @dataProvider sanitizeInputData
+   * @dataProvider sanitiseInputData
    */
-  public function testSanitize($input, $expected_output) {
+  public function testSanitise($input, $expected_output) {
     $this->assertEquals($expected_output, OrchestrationProviderBase::sanitise($input));
   }
 
   /**
-   * Test input data for sanitize test.
+   * Test input data for sanitise test.
    */
-  public function sanitizeInputData() {
+  public function sanitiseInputData() {
     return [
       ['ABC-123-fix-bug', 'abc-123-fix-bug'],
       ['ABC-123-under_score', 'abc-123-under_score'],


### PR DESCRIPTION
"Invalid image name" appears on deploy for a new environment using a branch name with a slash in it. E.g. "feature/some-feature".
Restore: node-707-y7d4s-s9npv
Cron: node-707-h8ny0-1533789000-q92nj

This means neither the database restore occurs, nor cronjobs run at the moment, because source refs (branch, tag or commit) aren't being sanitised for image stream names.