### PR TITLE
Archived state should be a default revision

### DIFF
--- a/config-export/workflows.workflow.shepherd.yml
+++ b/config-export/workflows.workflow.shepherd.yml
@@ -15,10 +15,10 @@ type: content_moderation
 type_settings:
   states:
     archived:
+      published: false
+      default_revision: true
       label: Archived
       weight: 1
-      published: false
-      default_revision: false
     draft:
       label: Draft
       weight: -1


### PR DESCRIPTION
Without this, https://github.com/universityofadelaide/shepherd/blob/master/web/modules/custom/shepherd/shp_custom/shp_custom.module#L123 will always back the environment up since the revision loaded will be the published version.