### PR TITLE
Delay creation of production route until a site is promoted.

### DIFF
--- a/web/modules/custom/shepherd/shp_orchestration/src/OrchestrationProviderInterface.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/OrchestrationProviderInterface.php
@@ -296,13 +296,11 @@ interface OrchestrationProviderInterface extends PluginInspectionInterface {
    *   The domain name of the site.
    * @param string $path
    *   The path of the site.
-   * @param array $annotations
-   *   An array of route annotations.
    *
    * @return bool
    *   Returns true if succeeded.
    */
-  public function createdSite(string $project_name, string $short_name, int $site_id, string $domain_name, string $path, array $annotations = []);
+  public function createdSite(string $project_name, string $short_name, int $site_id, string $domain_name, string $path);
 
   /**
    * Handles a site being updated.

--- a/web/modules/custom/shepherd/shp_orchestration/src/OrchestrationProviderInterface.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/OrchestrationProviderInterface.php
@@ -257,6 +257,12 @@ interface OrchestrationProviderInterface extends PluginInspectionInterface {
    *   Unique id of the site.
    * @param int $environment_id
    *   Unique id of the environment.
+   * @param string $domain_name
+   *   The domain name of the site.
+   * @param string $path
+   *   The path of the site.
+   * @param array $annotations
+   *   An array of route annotations.
    * @param string $source_ref
    *   Source code git ref, defaults to 'master'.
    * @param bool $clear_cache
@@ -270,6 +276,9 @@ interface OrchestrationProviderInterface extends PluginInspectionInterface {
     string $short_name,
     int $site_id,
     int $environment_id,
+    string $domain_name,
+    string $path,
+    array $annotations,
     string $source_ref = 'master',
     bool $clear_cache = TRUE
   );

--- a/web/modules/custom/shepherd/shp_orchestration/src/Plugin/OrchestrationProvider/DummyOrchestrationProvider.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/Plugin/OrchestrationProvider/DummyOrchestrationProvider.php
@@ -142,8 +142,7 @@ class DummyOrchestrationProvider extends OrchestrationProviderBase {
     string $short_name,
     int $site_id,
     string $domain,
-    string $path,
-    array $annotations = []
+    string $path
   ) {
     return TRUE;
   }

--- a/web/modules/custom/shepherd/shp_orchestration/src/Plugin/OrchestrationProvider/DummyOrchestrationProvider.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/Plugin/OrchestrationProvider/DummyOrchestrationProvider.php
@@ -125,6 +125,9 @@ class DummyOrchestrationProvider extends OrchestrationProviderBase {
     string $short_name,
     int $site_id,
     int $environment_id,
+    string $domain,
+    string $path,
+    array $annotations,
     string $source_ref = 'master',
     bool $clear_cache = TRUE
   ) {

--- a/web/modules/custom/shepherd/shp_orchestration/src/Plugin/OrchestrationProvider/OpenShiftOrchestrationProvider.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/Plugin/OrchestrationProvider/OpenShiftOrchestrationProvider.php
@@ -420,12 +420,26 @@ class OpenShiftOrchestrationProvider extends OrchestrationProviderBase {
     string $short_name,
     int $site_id,
     int $environment_id,
+    string $domain,
+    string $path,
+    array $annotations,
     string $source_ref = 'master',
     bool $clear_cache = TRUE
   ) {
     $site_deployment_name = self::generateDeploymentName($site_id);
 
     $environment_deployment_name = self::generateDeploymentName($environment_id);
+
+    // @todo - remove the hardcoded ports.
+    $port = 8080;
+
+    if (!$this->client->getService($site_deployment_name)) {
+      $this->client->createService($site_deployment_name, $site_deployment_name, $port, $port, $site_deployment_name);
+    }
+
+    if (!$this->client->getRoute($site_deployment_name)) {
+      $this->client->createRoute($site_deployment_name, $site_deployment_name, $domain, $path, $annotations);
+    }
 
     $result = $this->client->updateService($site_deployment_name, $environment_deployment_name);
     if ($result && $clear_cache) {
@@ -453,18 +467,6 @@ class OpenShiftOrchestrationProvider extends OrchestrationProviderBase {
     string $path,
     array $annotations = []
   ) {
-    $deployment_name = self::generateDeploymentName($site_id);
-
-    // @todo - make port a var and great .. so great .. yuge!
-    $port = 8080;
-    try {
-      $this->client->createService($deployment_name, $deployment_name, $port, $port, $deployment_name);
-      $this->client->createRoute($deployment_name, $deployment_name, $domain, $path, $annotations);
-    }
-    catch (ClientException $e) {
-      $this->handleClientException($e);
-      return FALSE;
-    }
     return TRUE;
   }
 

--- a/web/modules/custom/shepherd/shp_orchestration/src/Plugin/OrchestrationProvider/OpenShiftOrchestrationProvider.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/Plugin/OrchestrationProvider/OpenShiftOrchestrationProvider.php
@@ -464,8 +464,7 @@ class OpenShiftOrchestrationProvider extends OrchestrationProviderBase {
     string $short_name,
     int $site_id,
     string $domain,
-    string $path,
-    array $annotations = []
+    string $path
   ) {
     return TRUE;
   }

--- a/web/modules/custom/shepherd/shp_orchestration/src/Service/Environment.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/Service/Environment.php
@@ -306,11 +306,24 @@ class Environment extends EntityActionBase {
       return FALSE;
     }
 
+    // Load the taxonomy term that has protect enabled.
+    $promoted_term = $this->environmentType->getPromotedTerm();
+
+    // Extract and transform the annotations from the environment type.
+    $annotations = $promoted_term ? $promoted_term->field_shp_annotations->getValue() : [];
+    $annotations = array_combine(
+      array_column($annotations, 'key'),
+      array_column($annotations, 'value')
+    );
+
     $result = $this->orchestrationProviderPlugin->promotedEnvironment(
       $project->title->value,
       $site->field_shp_short_name->value,
       $site->id(),
       $environment->id(),
+      $site->field_shp_domain->value,
+      $site->field_shp_path->value,
+      $annotations,
       $environment->field_shp_git_reference->value,
       $clear_cache
     );

--- a/web/modules/custom/shepherd/shp_orchestration/src/Service/Site.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/Service/Site.php
@@ -54,23 +54,12 @@ class Site extends EntityActionBase {
   public function created(NodeInterface $site) {
     $project = $this->siteEntity->getProject($site);
 
-    // Load the taxonomy term that has protect enabled.
-    $promoted_term = $this->environmentType->getPromotedTerm();
-
-    // Extract and transform the annotations from the environment type.
-    $annotations = $promoted_term ? $promoted_term->field_shp_annotations->getValue() : [];
-    $annotations = array_combine(
-      array_column($annotations, 'key'),
-      array_column($annotations, 'value')
-    );
-
     return $this->orchestrationProviderPlugin->createdSite(
       $project->getTitle(),
       $site->field_shp_short_name->value,
       $site->id(),
       $site->field_shp_domain->value,
-      $site->field_shp_path->value,
-      $annotations
+      $site->field_shp_path->value
     );
   }
 


### PR DESCRIPTION
- Add in extra required parameters to the Interface, Dummy and Openshift providers
- Change promotion to:
  - Check if the service/route already exists
  - If not, create both
- Leave site creation still doing the call to the provider
- Remove creation of service/route when site is created from the provider level
- Move the annotations adjustments and domain/path to the promoted call