### PR TITLE
Remove backup volume and killswitch stuff that apparently does nothing.

### DIFF
--- a/web/modules/custom/shepherd/shp_orchestration/config/schema/shp_orchestration.schema.yml
+++ b/web/modules/custom/shepherd/shp_orchestration/config/schema/shp_orchestration.schema.yml
@@ -8,6 +8,3 @@ shp_orchestration.settings:
     queued_operations:
       type: boolean
       label: 'Enable queued operations. Ensures multiple actions are not executed concurrently for a given environment.'
-    backup_volumes_killswitch:
-      type: boolean
-      label: 'A global killswitch to turn off volume snapshots for a site'

--- a/web/modules/custom/shepherd/shp_orchestration/src/OrchestrationProviderInterface.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/OrchestrationProviderInterface.php
@@ -119,8 +119,6 @@ interface OrchestrationProviderInterface extends PluginInspectionInterface {
    *   An array of cron jobs associated with this environment.
    * @param array $annotations
    *   An array of route annotations.
-   * @param bool $backup_volumes
-   *   Whether to backup the volumes attached to this environment.
    * @param string $backup_schedule
    *   A schedule to run automated backups on, leave blank to disable.
    *
@@ -147,7 +145,6 @@ interface OrchestrationProviderInterface extends PluginInspectionInterface {
     array $probes = [],
     array $cron_jobs = [],
     array $annotations = [],
-    bool $backup_volumes = FALSE,
     string $backup_schedule = ''
   );
 

--- a/web/modules/custom/shepherd/shp_orchestration/src/Plugin/OrchestrationProvider/DummyOrchestrationProvider.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/Plugin/OrchestrationProvider/DummyOrchestrationProvider.php
@@ -66,7 +66,6 @@ class DummyOrchestrationProvider extends OrchestrationProviderBase {
     array $probes = [],
     array $cron_jobs = [],
     array $annotations = [],
-    bool $backup_volumes = FALSE,
     string $backup_schedule = ''
   ) {
     return TRUE;

--- a/web/modules/custom/shepherd/shp_orchestration/src/Plugin/OrchestrationProvider/OpenShiftOrchestrationProvider.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/Plugin/OrchestrationProvider/OpenShiftOrchestrationProvider.php
@@ -222,7 +222,6 @@ class OpenShiftOrchestrationProvider extends OrchestrationProviderBase {
     array $probes = [],
     array $cron_jobs = [],
     array $annotations = [],
-    bool $backup_volumes = FALSE,
     string $backup_schedule = ''
   ) {
     // @todo Refactor this. _The complexity is too damn high!_

--- a/web/modules/custom/shepherd/shp_orchestration/src/Service/Environment.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/Service/Environment.php
@@ -161,8 +161,6 @@ class Environment extends EntityActionBase {
       array_column($annotations, 'value')
     );
 
-    $backup_volumes_killswitch = $this->configFactory->get('shp_orchestration.settings')->get('backup_volumes_killswitch');
-    $backup_volumes = $node->field_shp_volume_snapshots->value && !$backup_volumes_killswitch;
     $backup_schedule = !$environment_type->field_shp_backup_schedule->isEmpty() ? $environment_type->field_shp_backup_schedule->value : '';
     $environment = $this->orchestrationProviderPlugin->createdEnvironment(
       $project->getTitle(),
@@ -184,7 +182,6 @@ class Environment extends EntityActionBase {
       $probes,
       $cron_jobs,
       $annotations,
-      $backup_volumes,
       $backup_schedule
     );
 


### PR DESCRIPTION
Found this backup volume snapshot stuff that doesn't appear to be used anywhere. I think its a leftover from ark/not required.