### PR TITLE
Create, update or delete environment backup schedule according to env…

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6077,12 +6077,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/universityofadelaide/openshift-client.git",
-                "reference": "96d56bb99dec4ff2b0b7746a8f07a7db3e8d041d"
+                "reference": "7e6305ce73704a2ffe2b55d7630a11d14944f721"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/universityofadelaide/openshift-client/zipball/96d56bb99dec4ff2b0b7746a8f07a7db3e8d041d",
-                "reference": "96d56bb99dec4ff2b0b7746a8f07a7db3e8d041d",
+                "url": "https://api.github.com/repos/universityofadelaide/openshift-client/zipball/7e6305ce73704a2ffe2b55d7630a11d14944f721",
+                "reference": "7e6305ce73704a2ffe2b55d7630a11d14944f721",
                 "shasum": ""
             },
             "require": {
@@ -6115,7 +6115,7 @@
                 }
             ],
             "description": "Simple OpenShift client for PHP.",
-            "time": "2019-09-08T22:56:32+00:00"
+            "time": "2020-01-29T03:41:51+00:00"
         },
         {
             "name": "universityofadelaide/shepherd-drupal-scaffold",

--- a/web/modules/custom/shepherd/shp_orchestration/src/OrchestrationProviderInterface.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/OrchestrationProviderInterface.php
@@ -189,6 +189,8 @@ interface OrchestrationProviderInterface extends PluginInspectionInterface {
    *   An array of cron jobs associated with this environment.
    * @param array $annotations
    *   An array of route annotations.
+   * @param string $backup_schedule
+   *   A schedule to run automated backups on, leave blank to disable.
    *
    * @return bool
    *   Returns true if succeeded.
@@ -212,7 +214,8 @@ interface OrchestrationProviderInterface extends PluginInspectionInterface {
     array $secrets = [],
     array $probes = [],
     array $cron_jobs = [],
-    array $annotations = []
+    array $annotations = [],
+    string $backup_schedule = ''
   );
 
   /**

--- a/web/modules/custom/shepherd/shp_orchestration/src/Plugin/OrchestrationProvider/DummyOrchestrationProvider.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/Plugin/OrchestrationProvider/DummyOrchestrationProvider.php
@@ -93,7 +93,8 @@ class DummyOrchestrationProvider extends OrchestrationProviderBase {
     array $secrets = [],
     array $probes = [],
     array $cron_jobs = [],
-    array $annotations = []
+    array $annotations = [],
+    string $backup_schedule = ''
   ) {
     return TRUE;
   }

--- a/web/modules/custom/shepherd/shp_orchestration/src/Plugin/OrchestrationProvider/OpenShiftOrchestrationProvider.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/Plugin/OrchestrationProvider/OpenShiftOrchestrationProvider.php
@@ -357,7 +357,8 @@ class OpenShiftOrchestrationProvider extends OrchestrationProviderBase {
     array $secrets = [],
     array $probes = [],
     array $cron_jobs = [],
-    array $annotations = []
+    array $annotations = [],
+    string $backup_schedule = ''
   ) {
     // @todo Refactor this too. Not DRY enough.
     $sanitised_project_name = self::sanitise($project_name);
@@ -415,6 +416,14 @@ class OpenShiftOrchestrationProvider extends OrchestrationProviderBase {
         $volumes,
         $deploy_data
       );
+    }
+
+    // Add/remove the backup schedule as determined by environment type.
+    if ($backup_schedule) {
+      $this->environmentScheduleBackupUpdate($site_id, $environment_id, $backup_schedule);
+    }
+    else {
+      $this->environmentScheduleBackupDelete($environment_id);
     }
 
     return TRUE;

--- a/web/modules/custom/shepherd/shp_orchestration/src/Service/Environment.php
+++ b/web/modules/custom/shepherd/shp_orchestration/src/Service/Environment.php
@@ -240,6 +240,9 @@ class Environment extends EntityActionBase {
       $storage_class = Term::load($project->field_shp_storage_class->target_id)->label();
     }
 
+    $environment_type = Term::load($node->field_shp_environment_type->target_id);
+    $backup_schedule = !$environment_type->field_shp_backup_schedule->isEmpty() ? $environment_type->field_shp_backup_schedule->value : '';
+
     $environment_updated = $this->orchestrationProviderPlugin->updatedEnvironment(
       $project->getTitle(),
       $site->field_shp_short_name->value,
@@ -258,7 +261,9 @@ class Environment extends EntityActionBase {
       $env_vars,
       $secrets,
       $probes,
-      $cron_jobs
+      $cron_jobs,
+      [],
+      $backup_schedule
     );
 
     // Allow other modules to react to the Environment update.
@@ -347,7 +352,6 @@ class Environment extends EntityActionBase {
     // @todo everything is exclusive for now, implement non-exclusive?
     // Load a non protected term.
     $demoted_term = $this->environmentType->getDemotedTerm();
-    $promoted_term = $this->environmentType->getPromotedTerm();
 
     // Demote all current prod environments - for this site!
     $old_promoted = \Drupal::entityQuery('node')


### PR DESCRIPTION
…ironment type.

Using `oc get backupscheduleds` to show the schedule, I've tested the following conditions:
* Single environment promote to production :heavy_check_mark:
* Single environment demote (edit env and set to dev) :heavy_check_mark:
* Multiple environment, promote env2 to prd and auto demote env1 to dev  :heavy_check_mark:

Requires https://github.com/universityofadelaide/openshift-client/pull/40