### PR TITLE
Added MINISHIFT_DRIVER variable to configure vm type.

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -54,7 +54,7 @@ minishift config set memory 4096
 minishift config set cpus 4
 ```
 
-Start Minishift, ready for the next step.
+Start Minishift, ready for the next step. 
 ```bash
 minishift start
 ```
@@ -82,6 +82,8 @@ Putting these into ~/.bashrc is recommended for ongoing development.
   `export OPENSHIFT_TYPE=openshift`
 * Set the domain for accessing shepherd to the ip of local docker
   `export DOMAIN=$(ip addr show docker0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1).nip.io`
+* Set the default minishift vm driver.
+  `export MINISHIFT_DRIVER=virtualbox`
 * Start the oc cluster with `./openshift start`.
 * Now run the ./dsh etc commands as per normal.
 

--- a/dsh
+++ b/dsh
@@ -52,6 +52,8 @@ fi
 dsh_openshift_init() {
   # Set default type of OpenShift installation if its not already set.
   : ${OPENSHIFT_TYPE:=minishift}
+  # Set the default minishift driver.
+  : ${MINISHIFT_DRIVER:=xhyve}
 
   # Password for the mysql server.
   SUPER_SECRET_PASSWORD=super-secret-password
@@ -68,7 +70,8 @@ dsh_openshift_init() {
 
     # Perform/check setup.
     if ! minishift status | grep "Running" > /dev/null; then
-      minishift start
+
+      minishift start --vm-driver ${MINISHIFT_DRIVER}
     fi
 
     # Ensure oc command is available.


### PR DESCRIPTION
Fixes an issue with the xhyve driver when running virtualbox 6.x.x

```
Error starting the VM: Error creating the VM. Error with pre-create check: "Virtual Box version 4 or lower will cause a kernel panicif xhyve tries to run. You are running version: 6.1.4r136177\n\n\t Please upgrade to version 5 at https://www.virtualbox.org/wiki/Downloads"
```