### PR TITLE
Set cache backend from field default.

### DIFF
--- a/web/modules/custom/shepherd/shp_backup/src/Form/EnvironmentUpgradeForm.php
+++ b/web/modules/custom/shepherd/shp_backup/src/Form/EnvironmentUpgradeForm.php
@@ -139,6 +139,12 @@ class EnvironmentUpgradeForm extends FormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $site = $form_state->get('site');
     $environment = $form_state->get('environment');
+
+    // Set cache plugin from field default value.
+    /** @var \Drupal\Core\Field\FieldDefinitionInterface $cache_backend */
+    $cache_backend = $environment->field_cache_backend->getFieldDefinition();
+    $environment->field_cache_backend->setValue($cache_backend->getDefaultValue($environment));
+
     if ($new_env = $this->backup->upgrade($site, $environment, $form_state->getValue('version'))) {
       $this->messenger->addStatus($this->t('Upgrade has been queued, new environment is being synced %title', [
         '%title' => $new_env->getTitle(),

--- a/web/modules/custom/shepherd/shp_backup/src/Plugin/Action/UpgradeEnvironment.php
+++ b/web/modules/custom/shepherd/shp_backup/src/Plugin/Action/UpgradeEnvironment.php
@@ -101,6 +101,12 @@ class UpgradeEnvironment extends ViewsBulkOperationsActionBase implements Plugin
       $this->messenger()->addError('No site found for @name.', ['@name' => $entity->label()]);
       return;
     }
+
+    // Set cache plugin from field default value.
+    /** @var \Drupal\Core\Field\FieldDefinitionInterface $cache_backend */
+    $cache_backend = $entity->field_cache_backend->getFieldDefinition();
+    $entity->field_cache_backend->setValue($cache_backend->getDefaultValue($entity));
+
     $this->backupService->upgrade($site, $entity, $this->configuration['version']);
   }
 


### PR DESCRIPTION
Currently, the source environment dictates the cache backend. This isn't ideal, because we're trying to move to a different backend. This PR uses the cache backend field default value to populate the new environment cache backend.