### PR TITLE
Create and use memcached imagestream from shepherd namespace.

### DIFF
--- a/DrupalContentGenerate.php
+++ b/DrupalContentGenerate.php
@@ -213,7 +213,7 @@ if (!$env = reset($nodes)) {
     'field_shp_memory_request' => [['value' => '256Mi']],
     'field_shp_memory_limit'   => [['value' => '512Mi']],
     'field_cache_backend'      => [
-      'plugin_id' => 'memcached_datagrid',
+      'plugin_id' => 'memcached_datagrid_yml',
     ],
   ]);
   $env->moderation_state->value = 'published';

--- a/deploy/local/memcached/memcached_imagestream.yml
+++ b/deploy/local/memcached/memcached_imagestream.yml
@@ -1,0 +1,18 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: memcached
+  annotations:
+    description: Track the memcached alpine image
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+    - name: alpine
+      annotations:
+        openshift.io/imported-from: 'docker.io/memcached:alpine'
+      from:
+        kind: DockerImage
+        name: 'docker.io/memcached:alpine'
+      referencePolicy:
+        type: Source

--- a/dsh
+++ b/dsh
@@ -87,6 +87,10 @@ dsh_openshift_init() {
   notice "Ensuring minio service exists"
   oc apply -f deploy/local/minio/
 
+  ## Setup the memcached alpine imagestream.
+  #notice "Setting up memcached alpine imagestream."
+  #oc apply -f deploy/local/memcached/
+
   # Setup the database password in an OpenShift secret.
   notice "Ensuring database secret exists."
   if ! oc get secret privileged-db-password > /dev/null 2>&1; then
@@ -134,6 +138,7 @@ dsh_openshift_init() {
       oc create serviceaccount "${SA}"
       oc adm policy add-cluster-role-to-user cluster-admin system:serviceaccount:shepherd-dev:"${SA}"
       oc adm policy add-cluster-role-to-user self-provisioner system:serviceaccount:shepherd-dev:"${SA}"
+      oc adm policy add-cluster-role-to-user system:image-puller system:serviceaccount:shepherd-dev:"${SA}"
       ${DEV_LOGIN}
 
       # This is pretty horrid, but there is no oc command in the dsh shell.

--- a/web/modules/custom/shepherd/shp_cache_backend/src/Plugin/CacheBackend/MemcachedDatagridYml.php
+++ b/web/modules/custom/shepherd/shp_cache_backend/src/Plugin/CacheBackend/MemcachedDatagridYml.php
@@ -440,6 +440,10 @@ class MemcachedDatagridYml extends CacheBackendBase {
    *   Memcache name.
    * @param string $memcached_port
    *   Memcache port.
+   * @param string $image_stream_tag
+   *   The image stream tag to use.
+   * @param string $image_stream_namespace
+   *   The namespace to load the image stream from.
    * @param array $data
    *   Array of data for labels.
    *


### PR DESCRIPTION
* Change default backend for the content generate to datagrid yml.
* Add creation of memcached imagestream to dsh, but commented.
* Add code in the memcache plugin to create and/or use memcache imagestream from shepherd namespace.